### PR TITLE
Filter toggle and crop button fixes, header, and general housekeeping

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -22,8 +22,18 @@ const Header = () => (
         height: 80,
         padding: 20,
         backgroundColor: "#f2f2f2"}}>
-      <div>
-        <p> Put stuff you want on the left in this div!</p>
+      <div
+        className="hero is-flex"
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between"
+        }}>
+          <img src="https://pennlabs.org/static/img/PennMobile.png" alt="Penn Mobile Logo" width="45" height="45"></img>
+          <div
+            style={{padding: 10}}>
+              <p>Penn Mobile Portal</p>
+          </div>
       </div>
       <div>
         <a href="/" className="button">Home</a>

--- a/src/components/PostCard.js
+++ b/src/components/PostCard.js
@@ -25,7 +25,7 @@ class PostCard extends React.Component {
           <div className="column is-one-quarter">
             <div className="columns is-vcentered is-mobile" style={{padding: "0px 20px"}}>
               <div className="column is-flex" style={{alignItems: "center"}}>
-                <img src={props.imageUrl} style={{width: "142px", height: "79px"} /*props.imageUrlCropped ?*/}/>
+                <img src={props.imageUrl} style={{width: "144px", height: "72px"} /*props.imageUrlCropped ?*/}/>
               </div>
               <div className="column has-text-centered">
                 <p className="is-size-5-desktop is-size-7-mobile" style={styles.smallPostText}>{props.name}</p>

--- a/src/pages/Post.js
+++ b/src/pages/Post.js
@@ -99,7 +99,6 @@ class PostPage extends React.Component {
     this.setCheckBoxState = this.setCheckBoxState.bind(this)
     this.showFilters = this.showFilters.bind(this)
     this.openModal = this.openModal.bind(this)
-    this.afterOpenModal = this.afterOpenModal.bind(this)
     this.closeModal = this.closeModal.bind(this)
   }
 
@@ -504,9 +503,7 @@ class PostPage extends React.Component {
 
     var filters = this.state.filters
     filters[type][id] = checked
-    this.setState({
-      filters: filters
-    })
+    this.setState({filters: filters})
   }
 
   updateDateRange(data) {
@@ -531,30 +528,18 @@ class PostPage extends React.Component {
   
   showFilters() {
     if (!this.state.filters['toggle']['enabled']) {
-      this.yearBoxesRef = "block"
-      this.schoolBoxesRef = "block"
       var filters = this.state.filters
       filters['toggle']['enabled'] = true
-      this.setState({
-        filters: filters
-      })
+      this.setState({filters: filters})
     } else {
-      this.yearBoxesRef = "none"
-      this.schoolBoxesRef = "none"
       var filters = this.state.filters
       filters['toggle']['enabled'] = false
-      this.setState({
-        filters: filters
-      })
+      this.setState({filters: filters})
     }
   }
 
   openModal() {
     this.setState({modalIsOpen: true})
-  }
-
-  afterOpenModal() {
-    this.setState({modalIsOpen: this.state.modalIsOpen})
   }
 
   closeModal() {
@@ -564,19 +549,21 @@ class PostPage extends React.Component {
 
   render() {
     const { crop, croppedImageUrl, src } = this.state;
-    let filterToggleText;
-    let filterToggleColor;
 
     if (this.state.filters['toggle']['enabled']) {
-      this.yearBoxesRef = "block"
-      this.schoolBoxesRef = "block"
-      filterToggleText = "Remove Filters";
-      filterToggleColor = "#a32512";
+      this.showFilterBoxes = "block"
+      this.filterToggleText = "Remove Filters";
+      this.filterToggleColor = "#a32512";
     } else {
-      this.yearBoxesRef = "none"
-      this.schoolBoxesRef = "none"
-      filterToggleText = "Add Filters";
-      filterToggleColor = "#12a340";
+      this.showFilterBoxes = "none"
+      this.filterToggleText = "Add Filters";
+      this.filterToggleColor = "#12a340";
+    }
+
+    if (this.state.imageUrl !== null) {
+      this.showCropButton = "block"
+    } else {
+      this.showCropButton = "none"
     }
 
     return(
@@ -612,17 +599,17 @@ class PostPage extends React.Component {
                           height: 30,
                           boxShadow: "0 2px 4px 0 rgba(0, 0, 0, 0.5)",
                           border: "solid 0 #979797",
-                          backgroundColor: filterToggleColor,
+                          backgroundColor: this.filterToggleColor,
                           fontFamily: "HelveticaNeue-Bold",
                           fontWeight: 500,
                           fontSize: 14,
                           color: "#ffffff"
                         }}>
-                          {filterToggleText}
+                          {this.filterToggleText}
                       </button>
                   </div>
 
-                  <div id="yearBoxes" style={{margin: "0px 40px 0px 40px", display: this.yearBoxesRef}}>
+                  <div id="yearBoxes" style={{margin: "0px 40px 0px 40px", display: this.showFilterBoxes}}>
                     <b style={{fontFamily: "HelveticaNeue-Medium", fontSize: "14px", float: "left", margin: "0px 0px 2px 0px"}}>Class Year</b>
                     <div className="field" id="yearCheck" style={{margin: "4px 0px 20px 0px", float: "center"}}>
                       <input className="is-checkradio is-small" id="year_0" type="checkbox" checked={this.state.filters.class.year_0} name="class_0" onClick={this.setCheckBoxState}/>
@@ -636,7 +623,7 @@ class PostPage extends React.Component {
                     </div>
                   </div>
 
-                  <div id="schoolBoxes" style={{margin: "0px 40px 0px 40px", display: this.yearBoxesRef}}>
+                  <div id="schoolBoxes" style={{margin: "0px 40px 0px 40px", display: this.showFilterBoxes}}>
                     <b style={{fontFamily: "HelveticaNeue-Medium", fontSize: "14px", float: "left", margin: "0px 0px 2px 0px"}}>School</b>
                     <div className="field" id="schoolCheck" style={{margin: "4px 0px 10px 0px", float: "center"}}>
                       <input className="is-checkradio is-small" id="COL" type="checkbox" checked={this.state.filters.school.COL} name="school_COL" onClick={this.setCheckBoxState}/>
@@ -743,7 +730,7 @@ class PostPage extends React.Component {
                             fontWeight: 500,
                             fontSize: 14,
                             color: "#ffffff",
-                            display: "none"
+                            display: this.showCropButton
                           }}>
                             Crop Image
                         </button>
@@ -752,7 +739,6 @@ class PostPage extends React.Component {
                   
                   <Modal
                     isOpen={this.state.modalIsOpen}
-                    onAfterOpen={this.afterOpenModal}
                     onRequestClose={this.closeModal}
                     style={this.state.modalStyle}
                     contentLabel="Cropping Modal">

--- a/src/pages/Post.js
+++ b/src/pages/Post.js
@@ -50,7 +50,7 @@ class PostPage extends React.Component {
       status: null,
       seniorClassYear: 2020,
       filters: {
-        toggle: {
+        options: {
           enabled: false
         },
         class: {
@@ -124,14 +124,14 @@ class PostPage extends React.Component {
         var filters = this.state.filters
         for (var filterObjKey in json.filters) {
           var filterObj = json.filters[filterObjKey]
-          if (filterObj.type !== 'email-only' && filterObj.type !== 'toggle') {
+          if (filterObj.type !== 'email-only' && filterObj.type !== 'options') {
             var filterKey = filterObj.filter
             if (filterObj.type === 'class') {
               filterKey = "year_" + (parseInt(filterObj.filter) - this.state.seniorClassYear)
             }
             filters[filterObj.type][filterKey] = true
-          } else if (filterObj.type == 'toggle') {
-            filters['toggle']['enabled'] = filterObj.filter
+          } else if (filterObj.type == 'options') {
+            filters.options.enabled = filterObj.filter
           }
         }
 
@@ -189,7 +189,7 @@ class PostPage extends React.Component {
         if (!filters.hasOwnProperty(type)) continue
         for (var key in filters[type]) {
           if (!filters[type].hasOwnProperty(key)) continue
-          if (type == 'toggle') {
+          if (type == 'options') {
             filters[type][key] = filters[type][key]
           } else {
             filters[type][key] = true
@@ -527,15 +527,9 @@ class PostPage extends React.Component {
   }
   
   showFilters() {
-    if (!this.state.filters['toggle']['enabled']) {
-      var filters = this.state.filters
-      filters['toggle']['enabled'] = true
-      this.setState({filters: filters})
-    } else {
-      var filters = this.state.filters
-      filters['toggle']['enabled'] = false
-      this.setState({filters: filters})
-    }
+    var filters = this.state.filters
+    filters.options.enabled = !filters.options.enabled
+    this.setState({filters: filters})
   }
 
   openModal() {
@@ -549,22 +543,6 @@ class PostPage extends React.Component {
 
   render() {
     const { crop, croppedImageUrl, src } = this.state;
-
-    if (this.state.filters['toggle']['enabled']) {
-      this.showFilterBoxes = "block"
-      this.filterToggleText = "Remove Filters";
-      this.filterToggleColor = "#a32512";
-    } else {
-      this.showFilterBoxes = "none"
-      this.filterToggleText = "Add Filters";
-      this.filterToggleColor = "#12a340";
-    }
-
-    if (this.state.imageUrl !== null) {
-      this.showCropButton = "block"
-    } else {
-      this.showCropButton = "none"
-    }
 
     return(
       <div style={{display: 'flex', flexDirection: 'column', alignItems: 'stretch', minHeight: '99vh'}}>
@@ -599,17 +577,17 @@ class PostPage extends React.Component {
                           height: 30,
                           boxShadow: "0 2px 4px 0 rgba(0, 0, 0, 0.5)",
                           border: "solid 0 #979797",
-                          backgroundColor: this.filterToggleColor,
+                          backgroundColor: this.state.filters.options.enabled ? "#a32512" : "#12a340",
                           fontFamily: "HelveticaNeue-Bold",
                           fontWeight: 500,
                           fontSize: 14,
                           color: "#ffffff"
                         }}>
-                          {this.filterToggleText}
+                          {this.state.filters.options.enabled ? "Remove Filters" : "Add Filters"}
                       </button>
                   </div>
 
-                  <div id="yearBoxes" style={{margin: "0px 40px 0px 40px", display: this.showFilterBoxes}}>
+                  <div id="yearBoxes" style={{margin: "0px 40px 0px 40px", display: this.state.filters.options.enabled ? "block" : "none"}}>
                     <b style={{fontFamily: "HelveticaNeue-Medium", fontSize: "14px", float: "left", margin: "0px 0px 2px 0px"}}>Class Year</b>
                     <div className="field" id="yearCheck" style={{margin: "4px 0px 20px 0px", float: "center"}}>
                       <input className="is-checkradio is-small" id="year_0" type="checkbox" checked={this.state.filters.class.year_0} name="class_0" onClick={this.setCheckBoxState}/>
@@ -623,7 +601,7 @@ class PostPage extends React.Component {
                     </div>
                   </div>
 
-                  <div id="schoolBoxes" style={{margin: "0px 40px 0px 40px", display: this.showFilterBoxes}}>
+                  <div id="schoolBoxes" style={{margin: "0px 40px 0px 40px", display: this.state.filters.options.enabled ? "block" : "none"}}>
                     <b style={{fontFamily: "HelveticaNeue-Medium", fontSize: "14px", float: "left", margin: "0px 0px 2px 0px"}}>School</b>
                     <div className="field" id="schoolCheck" style={{margin: "4px 0px 10px 0px", float: "center"}}>
                       <input className="is-checkradio is-small" id="COL" type="checkbox" checked={this.state.filters.school.COL} name="school_COL" onClick={this.setCheckBoxState}/>
@@ -730,7 +708,7 @@ class PostPage extends React.Component {
                             fontWeight: 500,
                             fontSize: 14,
                             color: "#ffffff",
-                            display: this.showCropButton
+                            display: this.state.imageUrl ? "block" : "none"
                           }}>
                             Crop Image
                         </button>


### PR DESCRIPTION
Another misleading branch name from Matthew.

Changes to filter toggle
- Switched to React refs from document.getElementById [#8](https://github.com/pennlabs/penn-mobile-portal/pull/8#discussion_r350528682)
- Checking button color and text in render() now, no longer setting state [#8](https://github.com/pennlabs/penn-mobile-portal/pull/8#discussion_r350528682)
- Button click status was being reset every time page was reloaded. Now loads properly.

Changes to crop button
- Fixed crop button not showing up when post page is reopened

Header improvements
- Replaced placeholder header with an actual header
<img width="1680" alt="Screen Shot 2019-12-10 at 5 17 30 PM" src="https://user-images.githubusercontent.com/18466677/70573960-f9d51580-1b70-11ea-8ab4-a22f24c76393.png">

Other changes
- Removed afterOpenModal [#8](https://github.com/pennlabs/penn-mobile-portal/pull/8#discussion_r350529888)